### PR TITLE
tweaks to get working on the rp2350 w/ arduino

### DIFF
--- a/examples/xbee_lr/xbee_lr.ino
+++ b/examples/xbee_lr/xbee_lr.ino
@@ -125,6 +125,8 @@ void setup() {
     serialPort = &Serial1;
 
     delay(6000);
+    Serial.println("");
+    Serial.println("----------------------------------------------------------------------");
     Serial.println("XBee LR Example App");
 
     // Initialize the XBee module
@@ -136,7 +138,18 @@ void setup() {
 
     // Read LoRaWAN DevEUI and print
     uint8_t devEui[17];
-    if (xbee->getLoRaWANDevEUI(devEui,sizeof(devEui))){
+
+    // This might take a few trys ... 
+    bool status = false; 
+    for(int i = 0; i < 3; i++){
+        if (xbee->getLoRaWANDevEUI(devEui,sizeof(devEui))){
+            status = true;
+            break;
+        }
+        delay(100);
+    }
+    // if (xbee->getLoRaWANDevEUI(devEui,sizeof(devEui))){
+    if (status){
       Serial.print("DEVEUI: ");
       Serial.print((char*)devEui);
     Serial.println();

--- a/src/XBeeArduino.cpp
+++ b/src/XBeeArduino.cpp
@@ -134,7 +134,7 @@ bool XBeeArduino::sendData(const T& data) {
     if (moduleType_ == XBEE_LORA) {
         return XBeeSendData(xbee_, &data) == 0;
     }
-    //return false;
+    return false;
 }
 
 // Explicit template instantiation for XBeeLRPacket_s

--- a/src/port_arduino.cpp
+++ b/src/port_arduino.cpp
@@ -58,6 +58,15 @@ int portUartInit(uint32_t baudrate, void *device) {
         ((HardwareSerial*)serialPort)->begin(baudrate);
     // }
 
+    // KDB - The arduino core doesn't set our pins to the correct function for the UART 
+    // see the helpful table here: https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+#if defined(PICO_RP2350)
+    if (PIN_SERIAL1_TX == 18 && PIN_SERIAL1_RX == 19 && device == &Serial1) {
+        gpio_set_function(PIN_SERIAL1_TX, (gpio_function_t)11);
+        gpio_set_function(PIN_SERIAL1_RX, (gpio_function_t)11);
+        uart_init(uart0, baudrate);
+    }
+#endif
     return 0; // Indicate success
 }
 
@@ -162,4 +171,5 @@ void portDebugPrintf(const char *format, ...) {
     vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
     Serial.print(buffer);
+    Serial.println();
 }

--- a/src/xbee_api_frames.c
+++ b/src/xbee_api_frames.c
@@ -129,7 +129,9 @@ int apiSendFrame(XBee* self, uint8_t frameType, const uint8_t *data, uint16_t le
         portDelay(1);
     }
 
+#if API_FRAME_DEBUG_PRINT_ENABLED
     uint32_t elapsed_time = portMillis() - startTime;
+#endif
     APIFrameDebugPrint("UART write completed in %lu ms\n", elapsed_time);
 
     // Return success if everything went well
@@ -435,6 +437,7 @@ int apiSendAtCommandAndGetResponse(XBee* self, at_command_t command, const uint8
 
 //Print out AT Response
 void xbeeHandleAtResponse(XBee* self, xbee_api_frame_t *frame) {
+#if API_FRAME_DEBUG_PRINT_ENABLED
     // The first byte of frame->data is the Frame ID
     uint8_t frame_id = frame->data[1];
 
@@ -444,8 +447,10 @@ void xbeeHandleAtResponse(XBee* self, xbee_api_frame_t *frame) {
     at_command[1] = frame->data[3];
     at_command[2] = '\0'; // Null-terminate the string
 
+
     // The next byte is the command status
     uint8_t command_status = frame->data[4];
+#endif
 
     // Print the basic information
     APIFrameDebugPrint("AT Response:\n");


### PR DESCRIPTION
Some tweaks I made to get this library to work with the RP2350 Arduino core. 

Changes:
- Tweaks/#defines to get the example to build when not in debug mode
- Work around issue in the Arduino core we are using for our RP2350 boards - the comm's UART (Serial1) RX/TX pins are not being set to the correct function for the RP2350. We will need to work with the Arduino core to get this fixed.

But it's this library is now working on an RP2350 with these changes. 