### PR TITLE
Fix compiler warnings being thrown - remove debug print 

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,11 +1,11 @@
 /**
  * @file config.h
  * @brief Define library configurations
- * 
- * 
+ *
+ *
  * @version 1.0
  * @date 2024-08-08
- * 
+ *
  * @license MIT
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,10 +13,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  * @author Felix Galindo
  * @contact felix.galindo@digi.com
  */
@@ -40,19 +40,19 @@ extern "C"
 #include "port.h"
 
 // Constants
-#define UART_READ_TIMEOUT_MS 3000   
+#define UART_READ_TIMEOUT_MS 3000
 #define UART_WRITE_TIMEOUT_MS 10
 
 #define API_FRAME_DEBUG_PRINT_ENABLED 0
 #if API_FRAME_DEBUG_PRINT_ENABLED
-#define APIFrameDebugPrint(...)             portDebugPrintf(__VA_ARGS__)
+#define APIFrameDebugPrint(...) portDebugPrintf(__VA_ARGS__)
 #else
 #define APIFrameDebugPrint(...)
 #endif
 
-#define XBEE_DEBUG_PRINT_ENABLED 1
+#define XBEE_DEBUG_PRINT_ENABLED 0
 #if XBEE_DEBUG_PRINT_ENABLED
-#define XBEEDebugPrintEnabled(...)             portDebugPrintf(__VA_ARGS__)
+#define XBEEDebugPrintEnabled(...) portDebugPrintf(__VA_ARGS__)
 #else
 #define XBEEDebugPrintEnabled(...)
 #endif

--- a/src/xbee_lr.c
+++ b/src/xbee_lr.c
@@ -477,7 +477,7 @@ bool XBeeLRSetJoinRX1Delay(XBee* self, const uint32_t value) {
     uint8_t responseLength;
     uint8_t paramLength = sizeof(value);
 
-    int status = apiSendAtCommandAndGetResponse(self, AT_J1, &value, paramLength, response, &responseLength, 5000);
+    int status = apiSendAtCommandAndGetResponse(self, AT_J1, (const uint8_t*)&value, paramLength, response, &responseLength, 5000);
 
     if (status != API_SEND_SUCCESS) {
         XBEEDebugPrintEnabled("Failed to set Join RX1 Delay\n");
@@ -500,7 +500,7 @@ bool XBeeLRSetJoinRX2Delay(XBee* self, const uint32_t value) {
     uint8_t responseLength;
     uint8_t paramLength = sizeof(value);
 
-    int status = apiSendAtCommandAndGetResponse(self, AT_J2, &value, paramLength, response, &responseLength, 5000);
+    int status = apiSendAtCommandAndGetResponse(self, AT_J2, (const uint8_t*)&value, paramLength, response, &responseLength, 5000);
 
     if (status != API_SEND_SUCCESS) {
         XBEEDebugPrintEnabled("Failed to set Join RX2 Delay\n");
@@ -523,7 +523,7 @@ bool XBeeLRSetRX1Delay(XBee* self, const uint32_t value) {
     uint8_t responseLength;
     uint8_t paramLength = sizeof(value);
 
-    int status = apiSendAtCommandAndGetResponse(self, AT_D1, &value, paramLength, response, &responseLength, 5000);
+    int status = apiSendAtCommandAndGetResponse(self, AT_D1, (const uint8_t*)&value, paramLength, response, &responseLength, 5000);
 
     if (status != API_SEND_SUCCESS) {
         XBEEDebugPrintEnabled("Failed to set RX1 Delay\n");
@@ -546,7 +546,7 @@ bool XBeeLRSetRX2Delay(XBee* self, const uint32_t value) {
     uint8_t responseLength;
     uint8_t paramLength = sizeof(value);
 
-    int status = apiSendAtCommandAndGetResponse(self, AT_D2, &value, paramLength, response, &responseLength, 5000);
+    int status = apiSendAtCommandAndGetResponse(self, AT_D2, (const uint8_t*)&value, paramLength, response, &responseLength, 5000);
 
     if (status != API_SEND_SUCCESS) {
         XBEEDebugPrintEnabled("Failed to set RX2 Delay\n");


### PR DESCRIPTION
Arduino builds were set to warnings = error and the library was throwing off some warnings. This fixes these.

Also removed print debug (set flag to 0 in config.h). Note: my auto-formatter got a hold of this file, but it's not that bad :) 

